### PR TITLE
Accepting hideModal from iframe to hide modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-fastauth-wallet",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "MIT",
   "scripts": {
     "build": "nx build --buildLibsFromSource --skip-nx-cache",

--- a/src/ui/IframeDialog.tsx
+++ b/src/ui/IframeDialog.tsx
@@ -91,7 +91,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
           zIndex={10000}
           destroyOnClose
           closeIcon={isIframeLoaded}
-          maskClosable={!isHidden}
+          maskClosable={false}
           styles={{
             header: {
               display: 'none',
@@ -128,7 +128,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
         width="auto"
         zIndex={10000}
         closeIcon={isIframeLoaded}
-        maskClosable={!isHidden}
+        maskClosable={false}
         destroyOnClose
         styles={{
           content: {

--- a/src/ui/IframeDialog.tsx
+++ b/src/ui/IframeDialog.tsx
@@ -24,7 +24,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
     const [isDialogOpen, setIsDialogOpen] = useState(isOpen);
     const [dialogHeight, setDialogHeight] = useState('0px');
     const [isIframeLoaded, setIsIframeLoaded] = useState(false);
-    const [hideModal, setHideModal] = useState(false);
+    const [isHidden, setIsHideModal] = useState(false);
 
     const handleOnMessage = (event: MessageEvent<MessageEventData>) => {
       if (event.data.dialogHeight) {
@@ -41,7 +41,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
       }
 
       if (event.data.hideModal) {
-        setHideModal(true);
+        setIsHideModal(true);
       }
     };
 
@@ -101,15 +101,15 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
               borderTopLeftRadius: '12px',
               height: dialogHeight,
               maxHeight: '80vh',
-              ...(hideModal ? { display: 'none' } : {}),
+              ...(isHidden ? { display: 'none' } : {}),
             },
             body: {
               width: '100%',
               padding: 0,
               overflow: 'hidden',
-              ...(hideModal ? { display: 'none' } : {}),
+              ...(isHidden ? { display: 'none' } : {}),
             },
-            ...(hideModal ? { mask: { display: 'none' },  } : {}),
+            ...(isHidden ? { mask: { display: 'none' },  } : {}),
           }}
         >
           {iframeElement}
@@ -131,15 +131,15 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
         styles={{
           content: {
             padding: 0,
-            ...(hideModal ? { display: 'none' } : {}),
+            ...(isHidden ? { display: 'none' } : {}),
           },
           body: {
             height: dialogHeight,
             width: '375px',
             borderRadius: '12px',
-            ...(hideModal ? { display: 'none' } : {}),
+            ...(isHidden ? { display: 'none' } : {}),
           },
-          ...(hideModal ? { mask: { display: 'none' } } : {}), // Hide modal (mask
+          ...(isHidden ? { mask: { display: 'none' } } : {}),
         }}
       >
         {iframeElement}

--- a/src/ui/IframeDialog.tsx
+++ b/src/ui/IframeDialog.tsx
@@ -91,6 +91,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
           zIndex={10000}
           destroyOnClose
           closeIcon={isIframeLoaded}
+          maskClosable={!isHidden}
           styles={{
             header: {
               display: 'none',
@@ -127,6 +128,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
         width="auto"
         zIndex={10000}
         closeIcon={isIframeLoaded}
+        maskClosable={!isHidden}
         destroyOnClose
         styles={{
           content: {

--- a/src/ui/IframeDialog.tsx
+++ b/src/ui/IframeDialog.tsx
@@ -11,7 +11,9 @@ export type IframeModalProps = {
 type MessageEventData = {
   dialogHeight?: number;
   closeIframe?: boolean;
+  hideModal?: boolean;
   onClose?: () => void;
+  type: string;
 };
 
 export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
@@ -22,6 +24,7 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
     const [isDialogOpen, setIsDialogOpen] = useState(isOpen);
     const [dialogHeight, setDialogHeight] = useState('0px');
     const [isIframeLoaded, setIsIframeLoaded] = useState(false);
+    const [hideModal, setHideModal] = useState(false);
 
     const handleOnMessage = (event: MessageEvent<MessageEventData>) => {
       if (event.data.dialogHeight) {
@@ -35,6 +38,10 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
 
       if (event.data.closeIframe) {
         handleDialogClose();
+      }
+
+      if (event.data.hideModal) {
+        setHideModal(true);
       }
     };
 
@@ -94,12 +101,15 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
               borderTopLeftRadius: '12px',
               height: dialogHeight,
               maxHeight: '80vh',
+              ...(hideModal ? { display: 'none' } : {}),
             },
             body: {
               width: '100%',
               padding: 0,
               overflow: 'hidden',
+              ...(hideModal ? { display: 'none' } : {}),
             },
+            ...(hideModal ? { mask: { display: 'none' },  } : {}),
           }}
         >
           {iframeElement}
@@ -121,12 +131,15 @@ export const IframeDialog = forwardRef<HTMLIFrameElement, IframeModalProps>(
         styles={{
           content: {
             padding: 0,
+            ...(hideModal ? { display: 'none' } : {}),
           },
           body: {
             height: dialogHeight,
             width: '375px',
             borderRadius: '12px',
+            ...(hideModal ? { display: 'none' } : {}),
           },
+          ...(hideModal ? { mask: { display: 'none' } } : {}), // Hide modal (mask
         }}
       >
         {iframeElement}


### PR DESCRIPTION
This PR contains implementation to accept `hideModal` from child iframe. Once it is received, it will apply css logic to hide UI. This feature is there to support the multi-chain domain Key flow where if domain === parent's origin -> hide Modal and execute the transaction straight away. 

