### PR TITLE
Bump version to 0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "near-fastauth-wallet",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "license": "MIT",
   "scripts": {
     "build": "nx build --buildLibsFromSource --skip-nx-cache",


### PR DESCRIPTION
This PR bump up the package version to 0.0.14

(Was attempt to release the package, but apparently 0.0.14 has been occupied already..)